### PR TITLE
Implemented interrupts for the Raspberry Pi

### DIFF
--- a/app-linux/src/receiver/main.cpp
+++ b/app-linux/src/receiver/main.cpp
@@ -15,9 +15,12 @@ int main(void) {
     }
     printf("CAN inited\n");
 
+    base.setup_interrupt(25);
+
     uint8_t buf[8];
     while (true) {
-        if (bus.get_message_status() == MessageState::MessagePending) {
+        base.wait_interrupt(500);
+        while (bus.get_message_status() == MessageState::MessagePending) {
             bus.read_buffer(8, buf);
             printf("Data from %d\n", bus.get_id());
             for (int i = 0; i < 8; ++i) {

--- a/driver/src/MCP2515.cpp
+++ b/driver/src/MCP2515.cpp
@@ -101,6 +101,10 @@ uint8_t MCP2515::begin(uint8_t canSpeed, uint8_t clockSpeed) {
             Register::RXB1CTRL,
             RXControlMask::AcceptAny,
             RXControlMask::AcceptAnyID);
+    m_base->modify_register(
+            Register::InterruptEnable,
+            InterruptFlag::RX0 | InterruptFlag::RX1,
+            InterruptFlag::RX0 | InterruptFlag::RX1);
     res = set_control_mode(m_base, Mode::Normal);
     if (Result::OK != res) {
         return Result::Failed;

--- a/linux/include/sys/mcp2515.h
+++ b/linux/include/sys/mcp2515.h
@@ -3,12 +3,16 @@
 
 #include <MCP2515Base.h>
 #include <linux/spi/spidev.h>
+#include <poll.h>
 
 namespace wlp {
     namespace linux {
         class MCP2515 : public wlp::MCP2515Base {
         public:
             MCP2515(const char *dev, int busSpeed);
+
+            int setup_interrupt(int gpio);
+            int wait_interrupt(int timeout);
 
             int begin(void);
 
@@ -27,6 +31,9 @@ namespace wlp {
             uint8_t m_mode;
             uint8_t m_lsbFirst;
             int m_fd;
+            int m_intfd;
+            struct pollfd m_pfd;
+            uint8_t m_garbage[8];
 
             spi_ioc_transfer m_spiBuffer[2];
         };

--- a/linux/src/MCP2515Linux.cpp
+++ b/linux/src/MCP2515Linux.cpp
@@ -1,7 +1,14 @@
 #include <stddef.h>
+#include <string.h>
+#include <stdio.h>
+#include <dirent.h>
+#include <stdarg.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <linux/limits.h>
 #include <sys/mcp2515.h>
 #include <sys/ioctl.h>
-#include <fcntl.h>
 
 using namespace wlp;
 
@@ -28,7 +35,7 @@ static void spi_process_transfers(int fd, spi_ioc_transfer *buf, uint8_t n) {
     }
     if (status != len) {
         if (status < 0) {
-            dprintf("[ERROR] SPI failed transfer\n");
+            dprintf("[ERROR] SPI failed transfer (%s)\n", strerror(errno));
         } else {
             dprintf("[ERROR] SPI incomplete transfer\n");
         }
@@ -63,7 +70,9 @@ linux::MCP2515::MCP2515(const char *dev, int busSpeed) :
         m_bitsPerWord(8),
         m_mode(0),
         m_lsbFirst(0),
-        m_fd(-1) {
+        m_fd(-1),
+        m_intfd(-1) {
+    m_pfd.fd = -1;
     m_spiBuffer[0] = {};
     m_spiBuffer[0].speed_hz = m_speed;
     m_spiBuffer[0].bits_per_word = m_bitsPerWord;
@@ -72,26 +81,103 @@ linux::MCP2515::MCP2515(const char *dev, int busSpeed) :
     m_spiBuffer[1].bits_per_word = m_bitsPerWord;
 }
 
+static int file_printf(const char *file, const char *format, ...) {
+    FILE *f = fopen(file, "w");
+    if (!f) {
+        dprintf("[ERROR] Failed to open %s\n", file);
+        return ERROR;
+    }
+    int ret;
+    va_list args;
+    va_start(args, format);
+    ret = vfprintf(f, format, args);
+    va_end(args);
+    fclose(f);
+    if(ret < 0) {
+        return ERROR;
+    }
+    return OK;
+}
+
+int linux::MCP2515::setup_interrupt(int gpio) {
+    if(file_printf("/sys/class/gpio/export", "%d", gpio) == ERROR) {
+        dprintf("[ERROR] Failed to export gpio pin\n");
+        return ERROR;
+    }
+
+    usleep(100000);
+
+    char path[PATH_MAX];
+
+    snprintf(path, PATH_MAX, "/sys/class/gpio/gpio%d/direction", gpio);
+
+    bool success = false;
+    for(int i = 0; i < 20; ++i) {
+        if(file_printf(path, "in") == ERROR) {
+            dprintf("[ERROR] Failed to set interrupt gpio direction, retrying\n");
+            usleep(100000);
+        } else {
+            success = true;
+            break;
+        }
+    }
+
+    if(!success) {
+        dprintf("[ERROR] Setting interrupt gpio direction unsuccessful\n");
+        return ERROR;
+    }
+
+    snprintf(path, PATH_MAX, "/sys/class/gpio/gpio%d/edge", gpio);
+    if(file_printf(path, "falling") == ERROR) {
+        dprintf("[ERROR] Failed to set interrupt gpio trigger edge\n");
+        return ERROR;
+    }
+
+    snprintf(path, PATH_MAX, "/sys/class/gpio/gpio%d/value", gpio);
+    m_intfd = open(path, O_RDONLY);
+    if(m_intfd < 0) {
+        dprintf("[ERROR] Failed to open: %s (%s)\n", path, strerror(errno));
+        return ERROR;
+    }
+
+    m_pfd.fd = m_intfd;
+    m_pfd.events = POLLPRI;
+
+    return OK;
+}
+
+int linux::MCP2515::wait_interrupt(int timeout) {
+    if(poll(&m_pfd, 1, timeout) < 0) {
+        dprintf("[ERROR] Poll failed (%s)\n", strerror(errno));
+        return ERROR;
+    }
+
+    lseek(m_intfd, 0, SEEK_SET);
+    read(m_intfd, m_garbage, sizeof(m_garbage));
+
+    return OK;
+}
+
 int linux::MCP2515::begin(void) {
     m_fd = open(m_dev, O_RDWR);
-    if (ERROR == m_fd) {
-        dprintf("[ERROR] Failed to open device: %s\n", m_dev);
+    if (m_fd < 0) {
+        dprintf("[ERROR] Failed to open device: %s (%s)\n", m_dev, strerror(errno));
         return ERROR;
     }
     if (ioctl(m_fd, SPI_IOC_WR_MODE, &m_mode)) {
-        dprintf("[ERROR] Failed to set SPI mode\n");
+        dprintf("[ERROR] Failed to set SPI mode (%s)\n", strerror(errno));
         return ERROR;
     }
     if (ioctl(m_fd, SPI_IOC_WR_LSB_FIRST, &m_lsbFirst)) {
-        dprintf("[ERROR] Failed to set LSB First\n");
+        dprintf("[ERROR] Failed to set LSB First (%s)\n", strerror(errno));
         return ERROR;
     }
     if (ioctl(m_fd, SPI_IOC_WR_BITS_PER_WORD, &m_bitsPerWord)) {
-        dprintf("[ERROR] Failed to set bits per word\n");
+        dprintf("[ERROR] Failed to set bits per word (%s)\n", strerror(errno));
         return ERROR;
     }
     if (ioctl(m_fd, SPI_IOC_WR_MAX_SPEED_HZ, &m_speed)) {
-        dprintf("[ERROR] Failed to set SPI speed\n");
+        dprintf("[ERROR] Failed to set SPI speed (%s)\n", strerror(errno));
         return ERROR;
     }
     return OK;


### PR DESCRIPTION
This adds the interrupts functionality for the Raspberry Pi. I've added a function you can call to wait for an interrupt from the mcp2515 without consuming CPU cycles.